### PR TITLE
- Added FixTime method to Utils class to prepend 0: to time in order …

### DIFF
--- a/NuGet/Trafilm.Metadata.nuspec
+++ b/NuGet/Trafilm.Metadata.nuspec
@@ -4,7 +4,7 @@
 
   <metadata>
     <id>Trafilm.Metadata</id>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <title>Trafilm.Metadata</title>
     <authors>birbilis</authors>
     <owners>birbilis</owners>

--- a/Tests/TestScene.cs
+++ b/Tests/TestScene.cs
@@ -1,6 +1,6 @@
 ﻿//Project: Trafilm.Metadata (https://github.com/Zoomicon/Trafilm.Metadata)
 //Filename: TestScene.cs
-//Version: 20160514
+//Version: 20160516
 
 using Trafilm.Metadata.Models;
 using Trafilm.Metadata.Utils;
@@ -29,7 +29,7 @@ namespace Trafilm.Metadata.Tests
       metadata.ReferenceId = "testFilm.testScene";
       metadata.FilmReferenceId = "testFilm";
       metadata.StartTime = "10:20:30.12".ToNullableTimeSpan(SceneMetadata.DEFAULT_POSITION_FORMAT);
-      metadata.Duration = "0:2:5.12".ToNullableTimeSpan(SceneMetadata.DEFAULT_DURATION_FORMAT);
+      metadata.Duration = "2:5.12".ToNullableTimeSpan(SceneMetadata.DEFAULT_DURATION_FORMAT);
       using (XmlWriter writer = Helpers.CreateXmlWriter(@"testFilm.testScene.cxml"))
         metadata.Save(writer);
     }

--- a/Tests/TestUtils.cs
+++ b/Tests/TestUtils.cs
@@ -1,0 +1,25 @@
+﻿//Project: Trafilm.Metadata (https://github.com/Zoomicon/Trafilm.Metadata)
+//Filename: TestScene.cs
+//Version: 20160516
+
+using Trafilm.Metadata.Models;
+using Trafilm.Metadata.Utils;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Xml;
+
+namespace Trafilm.Metadata.Tests
+{
+  [TestClass]
+  public class TestUtils
+  {
+    [TestMethod]
+    public void FixTime()
+    {
+      Assert.AreEqual("1:2:3.4", "1:2:3.4".FixTime());
+      Assert.AreEqual("0:2:3.4", "2:3.4".FixTime());
+      Assert.AreEqual("0:0:3.4", "3.4".FixTime());
+    }
+
+  }
+}

--- a/Tests/Trafilm.Metadata.Tests.csproj
+++ b/Tests/Trafilm.Metadata.Tests.csproj
@@ -56,6 +56,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Helpers.cs" />
+    <Compile Include="TestUtils.cs" />
     <Compile Include="TestUtterance.cs" />
     <Compile Include="TestScene.cs" />
     <Compile Include="TestFilm.cs" />

--- a/Utils/Converters.cs
+++ b/Utils/Converters.cs
@@ -1,6 +1,6 @@
 ﻿//Project: Trafilm.Metadata (https://github.com/Zoomicon/Trafilm.Metadata)
 //Filename: Converters.cs
-//Version: 20160514
+//Version: 20160516
 
 using System;
 using System.Globalization;
@@ -27,9 +27,22 @@ namespace Trafilm.Metadata.Utils
 
     //
 
+    public static string FixTime(this string value)
+    {
+      int count = 0;
+      foreach (char c in value)
+        if (c == ':')
+          count++;
+
+      for (int i = 0; i < 2 - count; i++)
+        value = "0:" + value;
+
+      return value;
+    }
+
     public static TimeSpan ToTimeSpan(this string value, string format) //throws exceptions 
     {
-      return TimeSpan.ParseExact(value, format, CultureInfo.InvariantCulture);
+      return TimeSpan.ParseExact(value.FixTime(), format, CultureInfo.InvariantCulture);
     }
 
     public static TimeSpan? ToNullableTimeSpan(this string value, string format)


### PR DESCRIPTION
…to make it into h:m:s.f format for TimeSpan parsing to work
- At Utils class, string.ToTimeSpan method now uses FixTime
- Updated NuGet package
